### PR TITLE
enable suds.transport console logging in sandbox

### DIFF
--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -122,6 +122,11 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'INFO',
         },
+        'suds.transport': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG is True else 'INFO',
+            'propagate': True,
+        },
         'oscar': {
             'handlers': ['console'],
             'level': 'DEBUG' if DEBUG is True else 'INFO',


### PR DESCRIPTION
Thinks it's a good idea to enable suds.transport console logging in sandbox