### PR TITLE
Hacked log handler for 'suds.transport'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,4 +8,4 @@ Inspired by:
 
 Contributions by:
 
-* you? :)
+* Jens Diemer

--- a/sandbox/log_handler.py
+++ b/sandbox/log_handler.py
@@ -1,18 +1,63 @@
+"""
+    Hacked log handler for 'suds.transport', that
+    just "reformat" newlines in binary representations
+
+    Usage, e.g.:
+
+        LOGGING = {
+            'version': 1,
+            'disable_existing_loggers': False,
+            'handlers': {
+                'console': {
+                    'class': 'logging.StreamHandler',
+                },
+                'suds_handler': {
+                    'class': 'sandbox.log_handler.SudsLogHandler',
+                }
+            },
+            'loggers': {
+                # ...
+                'suds.transport': {
+                    'handlers': ['suds_handler'],
+                    'level': 'DEBUG' if DEBUG is True else 'INFO',
+                    'propagate': True,
+                },
+                '# ...
+            },
+        }
+"""
+
 import logging
+
+from django.conf import settings
+
+# Hide the settings values from theses settings:
+HIDE_SETTING_NAMES = ("DOCDATA_MERCHANT_NAME", "DOCDATA_MERCHANT_PASSWORD")
 
 
 class SudsLogHandler(logging.StreamHandler):
-    """
-    Hack log handler for 'suds.transport', that
-    just "reformat" newlines in binary representations
-    """
-
     def emit(self, record):
         try:
             msg = self.format(record)
+            # Note: We get the "suds.transport" log output as strings.
+            # e.g.: MESSAGE is only a string representation of bytes.
 
-            msg = msg.replace("\\n", "\n")  # Hack ;)
+            # The Hack: reformat newlines:
+            msg = msg.replace("\\n", "\n")
 
+            # Replace sensitive setting values like passwords from log output:
+            for settings_name in HIDE_SETTING_NAMES:
+                settings_value = getattr(settings, settings_name, None)
+                if settings_value:
+                    if "\\" in settings_value:
+                        # e.g.: password contains a "\"-character
+                        # a normal replace will not match this
+                        # we have to replace the escaped version here
+                        settings_value = settings_value.replace("\\", "\\\\")
+
+                    msg = msg.replace(settings_value, "***")
+
+            # Do the output with some newlines:
             stream = self.stream
             stream.write(self.terminator)
             stream.write(msg)

--- a/sandbox/log_handler.py
+++ b/sandbox/log_handler.py
@@ -6,11 +6,12 @@ class SudsLogHandler(logging.StreamHandler):
     Hack log handler for 'suds.transport', that
     just "reformat" newlines in binary representations
     """
+
     def emit(self, record):
         try:
             msg = self.format(record)
 
-            msg = msg.replace("\\n", "\n") # Hack ;)
+            msg = msg.replace("\\n", "\n")  # Hack ;)
 
             stream = self.stream
             stream.write(self.terminator)

--- a/sandbox/log_handler.py
+++ b/sandbox/log_handler.py
@@ -1,0 +1,21 @@
+import logging
+
+
+class SudsLogHandler(logging.StreamHandler):
+    """
+    Hack log handler for 'suds.transport', that
+    just "reformat" newlines in binary representations
+    """
+    def emit(self, record):
+        try:
+            msg = self.format(record)
+
+            msg = msg.replace("\\n", "\n") # Hack ;)
+
+            stream = self.stream
+            stream.write(self.terminator)
+            stream.write(msg)
+            stream.write(self.terminator)
+            self.flush()
+        except Exception:
+            self.handleError(record)

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -116,11 +116,19 @@ LOGGING = {
         'console': {
             'class': 'logging.StreamHandler',
         },
+        'suds_handler': {
+            'class': 'sandbox.log_handler.SudsLogHandler',
+        }
     },
     'loggers': {
         'django': {
             'handlers': ['console'],
             'level': 'INFO',
+        },
+        'suds.transport': {
+            'handlers': ['suds_handler'],
+            'level': 'DEBUG' if DEBUG is True else 'INFO',
+            'propagate': True,
         },
         'oscar': {
             'handlers': ['console'],


### PR DESCRIPTION
I haved made a simple log handler for 'suds.transport' that will print the binary output a little bit better to the console.

The normal output:

![grafik](https://user-images.githubusercontent.com/71315/53087018-83debf80-3506-11e9-8681-262ec1ff4251.png)

With this hacked handler:

![grafik](https://user-images.githubusercontent.com/71315/53086971-64e02d80-3506-11e9-9be9-e85fda50e3b1.png)


Only tested for Python 3... Maybe Python 2 needs some extra handling...