### PR TITLE
Make sure to wrap select_for_update calls inside a transaction

### DIFF
--- a/oscar_docdata/views.py
+++ b/oscar_docdata/views.py
@@ -47,8 +47,9 @@ class UpdateOrderMixin(object):
         """
         Update the status of an order, by fetching the latest state from docdata.
         """
-        # Try to find the order.
-        # Block any other requests on the order until the status change is handled.
+        # Try to find the order and when found, lock the row.
+        # NOTE: you need to call this function inside a transaction!
+
         try:
             return DocdataOrder.objects.select_for_update().active_merchants().get(**{self.order_slug_field: order_slug})
         except DocdataOrder.DoesNotExist:

--- a/sandbox/apps/checkout/docdata.py
+++ b/sandbox/apps/checkout/docdata.py
@@ -143,7 +143,7 @@ def _on_order_status_updated(order, **kwargs):
     elif order.status == DocdataOrder.STATUS_CANCELLED:
         add_payment_event(oscar_order, "cancelled", order.total_registered, reference=order.order_key)
     else:
-        raise DocdataStatusError("Unknown order status: %r" % order.status)
+        raise DocdataStatusError(0, "Unknown order status: %s" % order.status)
 
 
 @receiver(signals.return_view_called)


### PR DESCRIPTION
Also fix this part:
```python
try:
    ddpayment = payment_class.objects.select_for_update().get(payment_id=str(payment.id))
except payment_class.DoesNotExist:
    # Create new line
    ddpayment = payment_class(
        docdata_order=order,
        payment_id=int(payment.id),
        payment_method=str(payment.paymentMethod),
    )
```
where `payment_id` can be a string or a int which makes no sense.

And some simplifications here and there